### PR TITLE
支持 Rails 5 和 6，set_page_title 可设置不显示 site_name

### DIFF
--- a/lib/seo_helper.rb
+++ b/lib/seo_helper.rb
@@ -8,7 +8,7 @@ module SeoHelper
 
   module Rails
     case ::Rails.version.to_s
-    when /^4/
+    when /^4/, /^5/, /^6/
       require "seo_helper/engine"
     when /^3\.[12]/
       require "seo_helper/engine3"

--- a/lib/seo_helper/configuration.rb
+++ b/lib/seo_helper/configuration.rb
@@ -14,7 +14,9 @@ module SeoHelper
     def initialize
       # Set default site_name according to the Rails application class name
       self.site_name    = ::Rails.application.class.to_s.split("::").first
-      self.skip_blank   = true
+
+      self.page_title_with_site_name = true
+      self.skip_blank                = true
 
       self.default_page_description = ""
       self.default_page_keywords    = ""

--- a/lib/seo_helper/configuration.rb
+++ b/lib/seo_helper/configuration.rb
@@ -6,6 +6,7 @@ module SeoHelper
     attr_accessor :default_page_keywords
     attr_accessor :default_page_image
 
+    attr_accessor :page_title_with_site_name
     attr_accessor :skip_blank
 
     attr_accessor :pagination_formatter

--- a/lib/seo_helper/helper.rb
+++ b/lib/seo_helper/helper.rb
@@ -81,9 +81,7 @@ module SeoHelper
         @page_title = title
       end
 
-      return unless with_site_name
-
-      @page_title = SeoHelper.format_site_name(@page_title, site_name)
+      @page_title = SeoHelper.format_site_name(@page_title, site_name) if with_site_name
     end
 
     def set_page_description(description)

--- a/lib/seo_helper/helper.rb
+++ b/lib/seo_helper/helper.rb
@@ -72,7 +72,7 @@ module SeoHelper
   module ControllerHelper
 
     # will also append current page number and the site name
-    def set_page_title(title, site_name = nil)
+    def set_page_title(title, site_name = nil, with_site_name: true)
       site_name ||= SeoHelper.configuration.site_name
 
       if params[:page]
@@ -80,6 +80,9 @@ module SeoHelper
       else
         @page_title = title
       end
+
+      return unless with_site_name
+
       @page_title = SeoHelper.format_site_name(@page_title, site_name)
     end
 

--- a/lib/seo_helper/helper.rb
+++ b/lib/seo_helper/helper.rb
@@ -72,7 +72,7 @@ module SeoHelper
   module ControllerHelper
 
     # will also append current page number and the site name
-    def set_page_title(title, site_name = nil, with_site_name: true)
+    def set_page_title(title, site_name = nil, with_site_name: SeoHelper.configuration.page_title_with_site_name)
       site_name ||= SeoHelper.configuration.site_name
 
       if params[:page]


### PR DESCRIPTION
* 支持 Rails 5 和 6
* set_page_title 方法添加 with_site_name 控制 page title 是否包含 site_name
* 添加 page_title_with_site_name 全局设置